### PR TITLE
Use the package installation script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,22 @@
 FROM vcatechnology/fedora-ci
 MAINTAINER VCA Technology <developers@vcatechnology.com>
 
+# Build-time metadata as defined at http://label-schema.org
+ARG PROJECT_NAME
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="$PROJECT_NAME" \
+      org.label-schema.description="An up-to-date Fedora image that has VCA tool chain packages installed" \
+      org.label-schema.url="https://www.debian.org/" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/vcatechnology/docker-fedora-toolchain" \
+      org.label-schema.vendor="VCA Technology" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.license=MIT \
+      org.label-schema.schema-version="1.0"
+
 # Install useful packages
 RUN sudo vca-install-package \
   gcc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM vcatechnology/fedora-ci:24
+FROM vcatechnology/fedora-ci
 MAINTAINER VCA Technology <developers@vcatechnology.com>
 
 # Install useful packages
-RUN sudo dnf install -y \
+RUN sudo vca-install-package \
   gcc \
   gcc-c++ \
   libtool \


### PR DESCRIPTION
The script performs the most optimal installation of packages to keep the image size as small as possible